### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ You can find the documentation [here](https://riv.readthedocs.org/en/latest/).
 
 Have a look at the [tutorial](https://riv.readthedocs.org/en/latest/tutorial.html).
 
-# Comparision to existing solutions #
+# Comparison to existing solutions #
 
 There are a couple of different REST frameworks for Django. The most
 well-known are Piston and Tastypie. Both of them are well-written and


### PR DESCRIPTION
@danrex, I've corrected a typographical error in the documentation of the [django-riv](https://github.com/danrex/django-riv) project. Specifically, I've changed comparision to comparison. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
